### PR TITLE
removed some whitespace to allow me to create a pull req

### DIFF
--- a/yelp_scrape.py
+++ b/yelp_scrape.py
@@ -97,10 +97,6 @@ def page_info_grab(pages: list) -> dict:
         page_attributes['Address'] = page_soup.find('p', class_='css-qyp8bo').text
         reccommendation_info[title] = page_attributes
     return reccommendation_info
-        
-
-
-
 
 @click.command()
 @click.option('--cache', '-c', default = Path("./WebCache/"), type = click.Path(exists=False), help = "When provided, changes the location of the cache.")


### PR DESCRIPTION
I added the page_info_grab function. There are some issues I would like to fix. If the url is too long yelp doesn't actually seem to display the whole thing anywhere so I need to look into alternate methods of getting that. Similarly with the rating I don't like needing to break out after finding the first 'aria-label'. It feels like that could easily break so I would like to find a more robust way of getting that info. I noticed it's listed on the bottom of most pages as well so maybe that's the way.

Please take a look and let me know if you have any thoughts. Thanks.